### PR TITLE
New kube-score validator

### DIFF
--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - uses: azure/setup-kubectl@v4
         id: install-kubectl
 
@@ -24,9 +21,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@cf79a64fed8a943fb1073260883d08fe0dfb4e56
 
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
-          sha:      ${{ github.event.pull_request.head.sha }}
+
+      - run: |
+          echo "Changed files detected:"
+          printf '%s\n' "${{ steps.changed-files.outputs.all_changed_files }}"
 
       - name: Build overlays for changed kustomizations
         env:

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -84,40 +84,36 @@ jobs:
           echo "Skip directives found:"
           cat /tmp/kskip.list || echo "(none)"
 
-
       - name: Validate kube‑score results
         shell: bash
         run: |
           sk=$(sed -E 's%^/kube-score skip %%' /tmp/kskip.list | sort -u)
-          echo "Skip list detected:"
-          printf '  - %s\n' $sk || true
-          echo "----------------------------------------"
 
           critical_lines=$(grep '^\[CRITICAL\]' /tmp/kube-score.ci || true)
-
           failures=0
+
           while IFS= read -r line; do
             [ -z "$line" ] && continue
 
-            # Clef normalisée "<apiVersion/Kind> <name>"
-            key=$(sed -E 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\2 \1/' <<< "$line")
+            # Clef "<name> <apiVersion/Kind>"
+            key=$(sed -E 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\1 \2/' <<< "$line")
 
             if grep -Fxq "$key" <<< "$sk"; then
               echo "⏭  $key (skipped)"
             else
               echo "::error::$line"
+              echo "↳  Pour ignorer : /kube-score skip $key"
               failures=1
             fi
           done <<< "$critical_lines"
 
+          #─────────────────────────────────────────
+          # 3) Sortie
+          #─────────────────────────────────────────
           if [ "$failures" -ne 0 ]; then
             echo
-            echo "❌  Unresolved CRITICAL findings detected."
-            echo "💡  To waive a finding, add a PR comment line like:"
-            echo "    /kube-score skip <apiVersion>/<Kind> <name>"
-            echo "    e.g.  /kube-score skip apps/v1/Deployment synapsets-web"
+            echo "❌  Des findings CRITICAL restent non résolus."
             exit 1
           fi
 
-          echo "✅  All CRITICAL findings fixed or explicitly skipped"
-
+          echo "✅  Tous les findings CRITICAL sont corrigés ou explicitement skip."

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -15,7 +15,8 @@ jobs:
 
       - name: Install kube-score
         run: |
-          kubectl krew install score
+          curl -sSL https://github.com/zegl/kube-score/releases/download/v1.20.0/kube-score_1.20.0_linux_amd64 -o /usr/local/bin/kube-score
+          chmod +x /usr/local/bin/kube-score
 
       - name: Get changed files
         id: changed-files
@@ -55,7 +56,6 @@ jobs:
       #     ignore-exit-code: true
 
       - name: Collect /kube-score skip directives
-        if: github.event_name == 'pull_request'
         id: skips
         shell: bash
         env:
@@ -98,5 +98,5 @@ jobs:
             echo "    e.g.  /kube-score skip apps/v1/Deployment synapsets-web"
             exit 1
           fi
-          
+
           echo "✅  All CRITICAL findings fixed or explicitly skipped"

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@cf79a64fed8a943fb1073260883d08fe0dfb4e56
+        with:
+          since_last_remote_commit: true
 
       - name: Build overlays for changed kustomizations
         env:

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -91,22 +91,27 @@ jobs:
             | .[]'
           > /tmp/kskip.list || true
 
-      - name: Validate kube-score results
+      - name: Validate kube‑score results
         shell: bash
         run: |
           sk=$(sed -E 's%^/kube-score skip %%' /tmp/kskip.list | sort -u)
           echo "Skip list detected:"; printf '  - %s\n' $sk || true
           echo "----------------------------------------"
 
-          # Extract CRITICAL objects from kube-score CI output
-          crit=$(sed -nE 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\2 \1/p' /tmp/kube-score.ci | sort -u)
-
           failures=0
-          for obj in $crit; do
-            if grep -Fxq "$obj" <<< "$sk"; then
-              echo "⏭  $obj  (skipped)"
+
+          grep '^\[CRITICAL\]' /tmp/kube-score.ci |
+          while IFS= read -r line; do
+            # line format: [CRITICAL] <name> <apiVersion/Kind>: <message>
+            # → transform into key "apiVersion/Kind name" to compare with skip list
+            name=$(echo "$line" | awk '{print $2}')
+            kind=$(echo "$line" | awk '{print $3}')
+            key="$kind $name"                       # e.g. apps/v1/StatefulSet mysql
+
+            if grep -Fxq "$key" <<< "$sk"; then
+              echo "⏭  $key (skipped)"
             else
-              echo "::error::$obj failed kube‑score"
+              echo "::error::$line"                 # full error with message
               failures=1
             fi
           done
@@ -114,7 +119,7 @@ jobs:
           if [ "$failures" -ne 0 ]; then
             echo
             echo "❌  Unresolved CRITICAL findings detected."
-            echo "💡  To waive a specific object, add a PR comment line like:"
+            echo "💡  To waive a finding, add a PR comment line like:"
             echo "    /kube-score skip <apiVersion>/<Kind> <name>"
             echo "    e.g.  /kube-score skip apps/v1/Deployment synapsets-web"
             exit 1

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -26,22 +26,30 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
+          set -x                        # <— trace toutes les commandes
           out_dir="out/kustomize"
           mkdir -p "$out_dir"
 
-          # Scan every tree that contains a kustomization.yaml
+          echo "Changed files detected:"
+          printf '%s\n' "$CHANGED_FILES"
+          echo "-----------------------"
+
+          shopt -s nullglob
           find ./apps ./bases -type f -name kustomization.yaml -not -path '*/base/*' -print0 |
           while IFS= read -r -d '' kustom; do
             dir="$(dirname "$kustom")"
             rel="${dir#./}"
-
-            #‑‑ test if *at least one* changed file lives inside that directory
             if printf '%s\n' "$CHANGED_FILES" | grep -qE "^${rel}(/|$)"; then
               name="${rel//\//_}.yaml"
               echo "▶ building $name"
               kubectl kustomize --enable-helm "$dir" > "$out_dir/$name"
+            else
+              echo "⏭ $rel (unchanged)"
             fi
           done
+
+          echo "---- Resulting manifests ----"
+          ls -l "$out_dir" || true
 
       - name: kube‑score check
         id: score

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -2,6 +2,10 @@ name: kube-score workflow
 
 on:
   workflow_call:
+    inputs:
+      pr:
+        required: false
+        type: number
 
 jobs:
   kube-score:
@@ -21,8 +25,6 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@cf79a64fed8a943fb1073260883d08fe0dfb4e56
-        with:
-          since_last_remote_commit: true
 
       - name: Build overlays for changed kustomizations
         env:

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -26,20 +26,25 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          set -x                        # <— trace toutes les commandes
+          set -euo pipefail
           out_dir="out/kustomize"
           mkdir -p "$out_dir"
 
-          echo "Changed files detected:"
-          printf '%s\n' "$CHANGED_FILES"
-          echo "-----------------------"
+          # 1) liste unique des apps touchées -> apps/<app>
+          to_rebuild=$(printf '%s\n' "$CHANGED_FILES" |
+                      awk -F/ '/^apps\// {print $1"/"$2}' |
+                      sort -u)
 
-          shopt -s nullglob
+          echo "Apps to rebuild:"; printf '  %s\n' $to_rebuild
+          echo "-----------------------------------------"
+
           find ./apps ./bases -type f -name kustomization.yaml -not -path '*/base/*' -print0 |
           while IFS= read -r -d '' kustom; do
-            dir="$(dirname "$kustom")"
-            rel="${dir#./}"
-            if printf '%s\n' "$CHANGED_FILES" | grep -qE "^${rel}(/|$)"; then
+            dir="$(dirname "$kustom")"              # ./apps/crabe/prod
+            rel="${dir#./}"                         # apps/crabe/prod
+            app_root=${rel%/*/*}                    # apps/crabe
+
+            if grep -Fxq "$app_root" <<< "$to_rebuild"; then
               name="${rel//\//_}.yaml"
               echo "▶ building $name"
               kubectl kustomize --enable-helm "$dir" > "$out_dir/$name"

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -21,21 +21,16 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@cf79a64fed8a943fb1073260883d08fe0dfb4e56
 
-
-      - run: |
-          echo "Changed files detected:"
-          printf '%s\n' "${{ steps.changed-files.outputs.all_changed_files }}"
-
       - name: Build overlays for changed kustomizations
-        env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -euo pipefail
           out_dir="out/kustomize"
           mkdir -p "$out_dir"
 
-          # 1) liste unique des apps touchées -> apps/<app>
-          to_rebuild=$(printf '%s\n' "$CHANGED_FILES" |
+          changed_files="${{ steps.changed-files.outputs.all_changed_files }}"
+
+          # 2) Remettre un fichier par ligne
+          to_rebuild=$(echo "$changed_files" | tr ' ' '\n' |
                       awk -F/ '/^apps\// {print $1"/"$2}' |
                       sort -u)
 
@@ -64,6 +59,7 @@ jobs:
 
           echo "---- Resulting manifests ----"
           ls -l "$out_dir" || true
+
 
       - name: kube‑score check
         id: score

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -108,7 +108,7 @@ jobs:
 
           if [ "$failures" -ne 0 ]; then
             echo
-            echo "❌  Des findings CRITICAL restent non résolus."
+            echo "❌  des findings CRITICAL sont encore présents."
             exit 1
           fi
 

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -2,10 +2,6 @@ name: kube-score workflow
 
 on:
   workflow_call:
-    inputs:
-      pr:
-        required: false
-        type: number
 
 jobs:
   kube-score:
@@ -27,6 +23,10 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@cf79a64fed8a943fb1073260883d08fe0dfb4e56
+
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha:      ${{ github.event.pull_request.head.sha }}
 
       - name: Build overlays for changed kustomizations
         env:

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -42,13 +42,13 @@ jobs:
 
           find ./apps ./bases -type f -name kustomization.yaml -not -path '*/base/*' -print0 |
           while IFS= read -r -d '' kustom; do
-            dir="$(dirname "$kustom")"          # ./apps/crabe/prod
-            rel="${dir#./}"                     # apps/crabe/prod
+            dir="$(dirname "$kustom")"
+            rel="${dir#./}"
 
             if [[ $rel == apps/*/* ]]; then
-              app_root=$(echo "$rel" | cut -d'/' -f1-2)   # apps/crabe
+              app_root=$(echo "$rel" | cut -d'/' -f1-2)
             else
-              app_root=${rel%%/*}                         # bases
+              app_root=${rel%%/*}
             fi
 
             if grep -Fxq "$app_root" <<< "$to_rebuild"; then
@@ -60,7 +60,6 @@ jobs:
             fi
           done
 
-
           echo "---- Resulting manifests ----"
           ls -l "$out_dir" || true
 
@@ -68,13 +67,6 @@ jobs:
         id: score
         run: |
           kube-score score --output-format ci ./out/kustomize/*.yaml | tee /tmp/kube-score.ci
-
-
-      # - name: kube-score check (Kustomize)
-      #   uses: piraces/kube-score-ga@v0.1.3
-      #   with:
-      #     manifests-folders: './out/kustomize/*.yaml'
-      #     ignore-exit-code: true
 
       - name: Collect /kube-score skip directives
         id: skips
@@ -102,16 +94,14 @@ jobs:
 
           grep '^\[CRITICAL\]' /tmp/kube-score.ci |
           while IFS= read -r line; do
-            # line format: [CRITICAL] <name> <apiVersion/Kind>: <message>
-            # → transform into key "apiVersion/Kind name" to compare with skip list
             name=$(echo "$line" | awk '{print $2}')
             kind=$(echo "$line" | awk '{print $3}')
-            key="$kind $name"                       # e.g. apps/v1/StatefulSet mysql
+            key="$kind $name"
 
             if grep -Fxq "$key" <<< "$sk"; then
               echo "⏭  $key (skipped)"
             else
-              echo "::error::$line"                 # full error with message
+              echo "::error::$line"
               failures=1
             fi
           done

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Validate kube‑score results
         shell: bash
         run: |
-          sk=$(sed -E 's%^/kube-score skip %%' /tmp/kskip.list | sort -u)
+          sk=$(sed -E 's%^/kube-score skip %%; s/\r$//' /tmp/kskip.list | sort -u)
 
           critical_lines=$(grep '^\[CRITICAL\]' /tmp/kube-score.ci || true)
           failures=0
@@ -95,8 +95,7 @@ jobs:
           while IFS= read -r line; do
             [ -z "$line" ] && continue
 
-            # Clef "<name> <apiVersion/Kind>"
-            key=$(sed -E 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\1 \2/' <<< "$line")
+            key=$(sed -E 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\1 \2/' <<< "$line" | tr -d '\r')
 
             if grep -Fxq "$key" <<< "$sk"; then
               echo "⏭  $key (skipped)"
@@ -107,9 +106,6 @@ jobs:
             fi
           done <<< "$critical_lines"
 
-          #─────────────────────────────────────────
-          # 3) Sortie
-          #─────────────────────────────────────────
           if [ "$failures" -ne 0 ]; then
             echo
             echo "❌  Des findings CRITICAL restent non résolus."

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -71,15 +71,19 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr view "$PR_NUMBER" --json body,comments --jq '
             ([.body] + [.comments[].body])
-            | map( split("\n")[] )
-            | map( select(startswith("/kube-score skip ")) )
+            | map(split("\n")[])
+            | map(select(startswith("/kube-score skip ")))
             | unique
-            | .[]'
-          > /tmp/kskip.list || true
+            | .[]
+          ' > /tmp/kskip.list || true
+
+          echo "Skip directives found:"
+          cat /tmp/kskip.list || echo "(none)"
+
 
       - name: Validate kube‑score results
         shell: bash

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -1,5 +1,5 @@
-name: kube-score workflow
-
+name: kube-score validator workflow
+# Works only with pull request triggers
 on:
   workflow_call:
 

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -1,0 +1,102 @@
+name: kube-score workflow
+
+on:
+  workflow_call:
+
+jobs:
+  kube-score:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: azure/setup-kubectl@v4
+        id: install-kubectl
+
+      - name: Install kube-score
+        run: |
+          kubectl krew install score
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@cf79a64fed8a943fb1073260883d08fe0dfb4e56
+
+      - name: Build overlays for changed kustomizations
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          out_dir="out/kustomize"
+          mkdir -p "$out_dir"
+
+          # Scan every tree that contains a kustomization.yaml
+          find ./apps ./bases -type f -name kustomization.yaml -not -path '*/base/*' -print0 |
+          while IFS= read -r -d '' kustom; do
+            dir="$(dirname "$kustom")"
+            rel="${dir#./}"
+
+            #‑‑ test if *at least one* changed file lives inside that directory
+            if printf '%s\n' "$CHANGED_FILES" | grep -qE "^${rel}(/|$)"; then
+              name="${rel//\//_}.yaml"
+              echo "▶ building $name"
+              kubectl kustomize --enable-helm "$dir" > "$out_dir/$name"
+            fi
+          done
+
+      - name: kube‑score check
+        id: score
+        run: |
+          kube-score score --output-format ci ./out/kustomize/*.yaml | tee /tmp/kube-score.ci
+
+
+      # - name: kube-score check (Kustomize)
+      #   uses: piraces/kube-score-ga@v0.1.3
+      #   with:
+      #     manifests-folders: './out/kustomize/*.yaml'
+      #     ignore-exit-code: true
+
+      - name: Collect /kube-score skip directives
+        if: github.event_name == 'pull_request'
+        id: skips
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          gh pr view "$PR_NUMBER" --json body,comments --jq '
+            ([.body] + [.comments[].body])
+            | map( split("\n")[] )
+            | map( select(startswith("/kube-score skip ")) )
+            | unique
+            | .[]'
+          > /tmp/kskip.list || true
+
+      - name: Validate kube-score results
+        shell: bash
+        run: |
+          sk=$(sed -E 's%^/kube-score skip %%' /tmp/kskip.list | sort -u)
+          echo "Skip list detected:"; printf '  - %s\n' $sk || true
+          echo "----------------------------------------"
+
+          # Extract CRITICAL objects from kube-score CI output
+          crit=$(sed -nE 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\2 \1/p' /tmp/kube-score.ci | sort -u)
+
+          failures=0
+          for obj in $crit; do
+            if grep -Fxq "$obj" <<< "$sk"; then
+              echo "⏭  $obj  (skipped)"
+            else
+              echo "::error::$obj failed kube‑score"
+              failures=1
+            fi
+          done
+
+          if [ "$failures" -ne 0 ]; then
+            echo
+            echo "❌  Unresolved CRITICAL findings detected."
+            echo "💡  To waive a specific object, add a PR comment line like:"
+            echo "    /kube-score skip <apiVersion>/<Kind> <name>"
+            echo "    e.g.  /kube-score skip apps/v1/Deployment synapsets-web"
+            exit 1
+          fi
+          
+          echo "✅  All CRITICAL findings fixed or explicitly skipped"

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -89,17 +89,18 @@ jobs:
         shell: bash
         run: |
           sk=$(sed -E 's%^/kube-score skip %%' /tmp/kskip.list | sort -u)
-          echo "Skip list detected:"; printf '  - %s\n' $sk || true
+          echo "Skip list detected:"
+          printf '  - %s\n' $sk || true
           echo "----------------------------------------"
 
           critical_lines=$(grep '^\[CRITICAL\]' /tmp/kube-score.ci || true)
 
           failures=0
           while IFS= read -r line; do
-            [ -z "$line" ] && continue   # ignore les lignes vides
+            [ -z "$line" ] && continue
 
-            # clé unique "apiVersion/Kind name"
-            key=$(awk '{print $3" "$2}' <<< "$line")
+            # Clef normalisée "<apiVersion/Kind> <name>"
+            key=$(sed -E 's/^\[CRITICAL\] +([^ ]+) +([^:]+):.*/\2 \1/' <<< "$line")
 
             if grep -Fxq "$key" <<< "$sk"; then
               echo "⏭  $key (skipped)"
@@ -119,3 +120,4 @@ jobs:
           fi
 
           echo "✅  All CRITICAL findings fixed or explicitly skipped"
+

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -40,9 +40,14 @@ jobs:
 
           find ./apps ./bases -type f -name kustomization.yaml -not -path '*/base/*' -print0 |
           while IFS= read -r -d '' kustom; do
-            dir="$(dirname "$kustom")"              # ./apps/crabe/prod
-            rel="${dir#./}"                         # apps/crabe/prod
-            app_root=${rel%/*/*}                    # apps/crabe
+            dir="$(dirname "$kustom")"          # ./apps/crabe/prod
+            rel="${dir#./}"                     # apps/crabe/prod
+
+            if [[ $rel == apps/*/* ]]; then
+              app_root=$(echo "$rel" | cut -d'/' -f1-2)   # apps/crabe
+            else
+              app_root=${rel%%/*}                         # bases
+            fi
 
             if grep -Fxq "$app_root" <<< "$to_rebuild"; then
               name="${rel//\//_}.yaml"
@@ -52,6 +57,7 @@ jobs:
               echo "⏭ $rel (unchanged)"
             fi
           done
+
 
           echo "---- Resulting manifests ----"
           ls -l "$out_dir" || true

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: azure/setup-kubectl@v4
         id: install-kubectl

--- a/.github/workflows/kube-score-validator.yml
+++ b/.github/workflows/kube-score-validator.yml
@@ -90,13 +90,14 @@ jobs:
           echo "Skip list detected:"; printf '  - %s\n' $sk || true
           echo "----------------------------------------"
 
-          failures=0
+          critical_lines=$(grep '^\[CRITICAL\]' /tmp/kube-score.ci || true)
 
-          grep '^\[CRITICAL\]' /tmp/kube-score.ci |
+          failures=0
           while IFS= read -r line; do
-            name=$(echo "$line" | awk '{print $2}')
-            kind=$(echo "$line" | awk '{print $3}')
-            key="$kind $name"
+            [ -z "$line" ] && continue   # ignore les lignes vides
+
+            # clé unique "apiVersion/Kind name"
+            key=$(awk '{print $3" "$2}' <<< "$line")
 
             if grep -Fxq "$key" <<< "$sk"; then
               echo "⏭  $key (skipped)"
@@ -104,7 +105,7 @@ jobs:
               echo "::error::$line"
               failures=1
             fi
-          done
+          done <<< "$critical_lines"
 
           if [ "$failures" -ne 0 ]; then
             echo

--- a/.github/workflows/kubernetes-repo-standards.yml
+++ b/.github/workflows/kubernetes-repo-standards.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   kubescore-check:
     uses:
-      clubcedille/cedille-workflows/.github/workflows/kube-score.yml@master
+      clubcedille/cedille-workflows/.github/workflows/kube-score-validator.yml@master
 
   yaml-check:
     uses:


### PR DESCRIPTION
- Only tracks changed files to trigger kube-score
- Allows to skip kube-score validation through PR comments. 

Snippet of output from ci : 
<img width="912" height="809" alt="image" src="https://github.com/user-attachments/assets/529b4bca-0d59-405e-8964-1e71d0048354" />

Lines were skipped using following comments as proposed by the ci output : 
<img width="1058" height="547" alt="image" src="https://github.com/user-attachments/assets/0c09c744-858b-4697-9383-b8bfa05618e7" />
